### PR TITLE
Use background color from material theme in new tiles

### DIFF
--- a/library/src/androidMain/kotlin/ovh/plrapps/mapcompose/ui/view/TileCanvas.android.kt
+++ b/library/src/androidMain/kotlin/ovh/plrapps/mapcompose/ui/view/TileCanvas.android.kt
@@ -3,7 +3,9 @@ package ovh.plrapps.mapcompose.ui.view
 import android.graphics.Paint
 import android.graphics.Rect
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -37,6 +39,7 @@ internal actual fun TileCanvas(
 
     Canvas(
         modifier = modifier
+            .background(MaterialTheme.colors.background)
             .fillMaxSize()
     ) {
         withTransform({

--- a/library/src/desktopMain/kotlin/ovh/plrapps/mapcompose/ui/view/TileCanvas.desktop.kt
+++ b/library/src/desktopMain/kotlin/ovh/plrapps/mapcompose/ui/view/TileCanvas.desktop.kt
@@ -1,7 +1,9 @@
 package ovh.plrapps.mapcompose.ui.view
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -38,6 +40,7 @@ internal actual fun TileCanvas(
 
     Canvas(
         modifier = modifier
+            .background(MaterialTheme.colors.background)
             .fillMaxSize()
     ) {
         withTransform({

--- a/library/src/iosMain/kotlin/ovh/plrapps/mapcompose/ui/view/TileCanvas.ios.kt
+++ b/library/src/iosMain/kotlin/ovh/plrapps/mapcompose/ui/view/TileCanvas.ios.kt
@@ -1,7 +1,9 @@
 package ovh.plrapps.mapcompose.ui.view
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -38,6 +40,7 @@ internal actual fun TileCanvas(
 
     Canvas(
         modifier = modifier
+            .background(MaterialTheme.colors.background)
             .fillMaxSize()
     ) {
         withTransform({


### PR DESCRIPTION
Color new tiles according to set theme so they are not white in dark mode apps while loading.