### PR TITLE
Add `popLayer` and `popMultipleLayers` to `LayerApi`

### DIFF
--- a/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/api/LayerApi.kt
+++ b/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/api/LayerApi.kt
@@ -127,6 +127,7 @@ fun MapState.popLayer() {
 
 /**
  * Pop the top [numberOfLayers] layers from the stack.
+ * @param numberOfLayers The number of layers to pop.
  */
 fun MapState.popMultipleLayers(numberOfLayers: Int) {
     val layers = tileCanvasState.layerFlow.value.toMutableList()

--- a/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/api/LayerApi.kt
+++ b/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/api/LayerApi.kt
@@ -115,6 +115,30 @@ fun MapState.moveLayerDown(layerId: String) {
 }
 
 /**
+ * Pop the top layer from the stack.
+ */
+fun MapState.popLayer() {
+    val layers = tileCanvasState.layerFlow.value.toMutableList()
+    if (layers.isNotEmpty()) {
+        layers.removeAt(layers.lastIndex)
+        setLayers(layers)
+    }
+}
+
+/**
+ * Pop the top [numberOfLayers] layers from the stack.
+ */
+fun MapState.popMultipleLayers(numberOfLayers: Int) {
+    val layers = tileCanvasState.layerFlow.value.toMutableList()
+    if (layers.size >= numberOfLayers) {
+        repeat(numberOfLayers) {
+            layers.removeAt(layers.lastIndex)
+        }
+        setLayers(layers)
+    }
+}
+
+/**
  * Reorder layers in the order of the provided list of ids. Layers listed first will be drawn before
  * subsequent layers (so the later will be above).
  * Existing layers not included in the provided list will be removed

--- a/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/api/LayerApi.kt
+++ b/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/api/LayerApi.kt
@@ -115,28 +115,22 @@ fun MapState.moveLayerDown(layerId: String) {
 }
 
 /**
- * Pop the top layer from the stack.
+ * Remove the top layer from the stack.
  */
-fun MapState.popLayer() {
+fun MapState.removeLastLayer() {
     val layers = tileCanvasState.layerFlow.value.toMutableList()
-    if (layers.isNotEmpty()) {
-        layers.removeAt(layers.lastIndex)
-        setLayers(layers)
-    }
+    val remainingLayers = layers.subList(0, layers.size - 1)
+    setLayers(remainingLayers)
 }
 
 /**
- * Pop the top [numberOfLayers] layers from the stack.
- * @param numberOfLayers The number of layers to pop.
+ * Remove the top [n] layers from the stack.
+ * @param n The number of layers to remove.
  */
-fun MapState.popMultipleLayers(numberOfLayers: Int) {
+fun MapState.removeLastLayers(n: Int) {
     val layers = tileCanvasState.layerFlow.value.toMutableList()
-    if (layers.size >= numberOfLayers) {
-        repeat(numberOfLayers) {
-            layers.removeAt(layers.lastIndex)
-        }
-        setLayers(layers)
-    }
+    val remainingLayers = layers.subList(0, (layers.size - n).coerceAtLeast(0))
+    setLayers(remainingLayers)
 }
 
 /**


### PR DESCRIPTION
This merge request introduces two new extension functions to the `LayerApi`. In my app I allow users to select the layer. The layers stack so for example if the user had level 1 selected  and then they move to level 8 the app would iteratively push levels 2...8. But if the user wanted to move back to level 1 this required removing all layers and redrawing the stack using the `setMapLayer` function as we cannot know the uuids of the current map layers on the stack. 

With the new `popLayer` and `popMultipleLayers` functions, the process becomes more efficient and removes the need for a temporary black screen while the BaseLayer is redrawn.

#### Code before:

```kotlin
fun setMapLayer(layer: Int) {
    if (layer == 0) {
        state.removeAllLayers()
        state.addLayer(
            getTileStreamProvider(0, LayerType.JPG.extension),
            placement = BelowAll
        )
    } else if (layer < selectedLayer.value) {
        state.removeAllLayers()
        state.addLayer(
            getTileStreamProvider(0, LayerType.JPG.extension),
            placement = BelowAll
        )
        for (i in 1..layer) {
            state.addLayer(
                getTileStreamProvider(i, LayerType.PNG.extension),
                placement = AboveAll
            )
        }
    } else if (layer > selectedLayer.value) {
        for (i in (selectedLayer.value + 1)..layer) {
            state.addLayer(
                getTileStreamProvider(i, LayerType.PNG.extension),
                placement = AboveAll
            )
        }
    }
    selectedLayer.value = layer
}
```

#### Code with `popMultipleLayers`:

With the introduction of `popLayer` and `popMultipleLayers`, the implementation is streamlined:

```kotlin
fun setMapLayer(layer: Int) {
    when {
        layer < selectedLayer.value -> {
            // Pop layers to move to a lower level.
            state.popMultipleLayers(selectedLayer.value - layer)
        }
        layer > selectedLayer.value -> {
            // Add layers to move to a higher level.
            for (i in (selectedLayer.value + 1)..layer) {
                state.addLayer(
                    getTileStreamProvider(i, LayerType.PNG.extension),
                    placement = AboveAll
                )
            }
        }
    }
    selectedLayer.value = layer
}
```

Let me know if you’d like further adjustments! Cheers :)